### PR TITLE
link_toの遷移先をPrefixで指定

### DIFF
--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -5,7 +5,7 @@
         <span><%= image_tag 'arrow_top.png' %></span>
         <ul class="more_list">
           <li>
-            <%= link_to '削除', "/tweets/#{tweet.id}", method: :delete %>
+            <%= link_to '削除', tweet_path(tweet.id), method: :delete %>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
rails routes
でdestroyアクションに対応するPrefixはtweetということが分かる