### PR TITLE
searchアクションのルーティングを設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   root to: 'tweets#index'
   resources :tweets do
     resources :comments, only: :create
+    collection do
+      get 'search'
+    end
   end
   resources :users, only: :show
 end


### PR DESCRIPTION
URLの指定先が、collectionは:idなし、memberが:idありとなっている